### PR TITLE
Add PDF generation for payroll and editable fields

### DIFF
--- a/folha-pagamento.php
+++ b/folha-pagamento.php
@@ -276,16 +276,6 @@ while ($r = $res->fetch_assoc())
     <div class="card">
         <?php if (empty($lista)): ?>Nenhuma folha para este período.<?php else: ?>
             
-<form method="post" action="gerar_pdf.php" target="_blank" style="margin-bottom: 20px;">
-    <input type="hidden" name="colaborador" value="<?= $nome_colaborador ?>">
-    <input type="hidden" name="salario_base" value="<?= $salario_base ?>">
-    <input type="hidden" name="horas_extras" value="<?= $horas_extras ?>">
-    <input type="hidden" name="inss" value="<?= $inss ?>">
-    <input type="hidden" name="irrf" value="<?= $irrf ?>">
-    <input type="hidden" name="outros_descontos" value="<?= $outros_descontos ?>">
-    <input type="hidden" name="salario_liquido" value="<?= $salario_liquido ?>">
-    <button type="submit">📄 Gerar Folha de Pagamento em PDF</button>
-</form>
 
 <table>
                 <thead>
@@ -317,19 +307,30 @@ while ($r = $res->fetch_assoc())
                         <tr>
                             <td><?= $f['id'] ?></td>
                             <td><?= htmlspecialchars($f['nome']) ?></td>
-                            <td><?= number_format($f['salario_base'], 2, ',', '.') ?></td>
-                            <td><?= number_format($f['horas_trabalhadas'], 2, ',', '.') ?></td>
-                            <td><?= number_format($notWorked, 2, ',', '.') ?></td>
-                            <td><?= number_format($valorNot, 2, ',', '.') ?></td>
-                            <td><?= number_format($f['horas_extras'], 2, ',', '.') ?></td>
-                            <td><?= number_format($f['valor_extras'], 2, ',', '.') ?></td>
-                            <td><input type="text" name="outros_descontos[<?= $f['id'] ?>]"
-                                    value="<?= number_format($outrosDesc, 2, ',', '.') ?>" style="width:6ch;"></td>
-                            <td><?= number_format($descContrato, 2, ',', '.') ?></td>
-                            <td><?= number_format($f['desconto_inss'], 2, ',', '.') ?></td>
-                            <td><?= number_format($f['desconto_irrf'], 2, ',', '.') ?></td>
-                            <td><?= number_format($f['salario_liquido'], 2, ',', '.') ?></td>
+                            <td><input type="text" name="salario_base[<?= $f['id'] ?>]" value="<?= number_format($f['salario_base'], 2, ',', '.') ?>" style="width:6ch;"></td>
+                            <td><input type="text" name="horas_trabalhadas[<?= $f['id'] ?>]" value="<?= number_format($f['horas_trabalhadas'], 2, ',', '.') ?>" style="width:6ch;"></td>
+                            <td><input type="text" name="horas_nao_trabalhadas[<?= $f['id'] ?>]" value="<?= number_format($notWorked, 2, ',', '.') ?>" style="width:6ch;"></td>
+                            <td><input type="text" name="valor_horas_nao_trabalhadas[<?= $f['id'] ?>]" value="<?= number_format($valorNot, 2, ',', '.') ?>" style="width:6ch;"></td>
+                            <td><input type="text" name="horas_extras[<?= $f['id'] ?>]" value="<?= number_format($f['horas_extras'], 2, ',', '.') ?>" style="width:6ch;"></td>
+                            <td><input type="text" name="valor_extras[<?= $f['id'] ?>]" value="<?= number_format($f['valor_extras'], 2, ',', '.') ?>" style="width:6ch;"></td>
+                            <td><input type="text" name="outros_descontos[<?= $f['id'] ?>]" value="<?= number_format($outrosDesc, 2, ',', '.') ?>" style="width:6ch;"></td>
+                            <td><input type="text" name="desc_contrato[<?= $f['id'] ?>]" value="<?= number_format($descContrato, 2, ',', '.') ?>" style="width:6ch;"></td>
+                            <td><input type="text" name="desconto_inss[<?= $f['id'] ?>]" value="<?= number_format($f['desconto_inss'], 2, ',', '.') ?>" style="width:6ch;"></td>
+                            <td><input type="text" name="desconto_irrf[<?= $f['id'] ?>]" value="<?= number_format($f['desconto_irrf'], 2, ',', '.') ?>" style="width:6ch;"></td>
+                            <td><input type="text" name="salario_liquido[<?= $f['id'] ?>]" value="<?= number_format($f['salario_liquido'], 2, ',', '.') ?>" style="width:6ch;"></td>
                             <td><?= $f['status'] ?></td>
+                            <td>
+                                <form method="post" action="gerar_pdf.php" target="_blank" style="display:inline;">
+                                    <input type="hidden" name="colaborador" value="<?= htmlspecialchars($f['nome'], ENT_QUOTES) ?>">
+                                    <input type="hidden" name="salario_base" value="<?= $f['salario_base'] ?>">
+                                    <input type="hidden" name="horas_extras" value="<?= $f['horas_extras'] ?>">
+                                    <input type="hidden" name="inss" value="<?= $f['desconto_inss'] ?>">
+                                    <input type="hidden" name="irrf" value="<?= $f['desconto_irrf'] ?>">
+                                    <input type="hidden" name="outros_descontos" value="<?= $outrosDesc ?>">
+                                    <input type="hidden" name="salario_liquido" value="<?= $f['salario_liquido'] ?>">
+                                    <button type="submit" style="padding:0 4px;">📄</button>
+                                </form>
+                            </td>
                         </tr>
                     <?php endforeach; ?>
                 </tbody>

--- a/gerar_pdf.php
+++ b/gerar_pdf.php
@@ -1,0 +1,40 @@
+<?php
+require_once 'fpdf.php';
+
+$colaborador = $_POST['colaborador'] ?? '';
+$salario_base = floatval(str_replace([',','.'],['','.'], $_POST['salario_base'] ?? 0));
+$horas_extras = floatval(str_replace([',','.'],['','.'], $_POST['horas_extras'] ?? 0));
+$inss = floatval(str_replace([',','.'],['','.'], $_POST['inss'] ?? 0));
+$irrf = floatval(str_replace([',','.'],['','.'], $_POST['irrf'] ?? 0));
+$outros = floatval(str_replace([',','.'],['','.'], $_POST['outros_descontos'] ?? 0));
+$salario_liquido = floatval(str_replace([',','.'],['','.'], $_POST['salario_liquido'] ?? 0));
+
+$pdf = new FPDF();
+$pdf->AddPage();
+$pdf->SetFont('Arial','B',16);
+$pdf->Cell(0,10,"Sushi House's",0,1,'C');
+$pdf->SetFont('Arial','',12);
+$pdf->Cell(0,10,'CNPJ 28458251000133',0,1,'C');
+$pdf->Ln(10);
+
+$pdf->SetFont('Arial','B',14);
+$pdf->Cell(0,10,'Folha de Pagamento',0,1,'C');
+$pdf->Ln(5);
+$pdf->SetFont('Arial','',12);
+$pdf->Cell(50,8,'Colaborador:');
+$pdf->Cell(0,8,$colaborador,0,1);
+$pdf->Cell(50,8,'Salario Base:');
+$pdf->Cell(0,8,number_format($salario_base,2,',','.'),0,1);
+$pdf->Cell(50,8,'Horas Extras:');
+$pdf->Cell(0,8,number_format($horas_extras,2,',','.'),0,1);
+$pdf->Cell(50,8,'Desconto INSS:');
+$pdf->Cell(0,8,number_format($inss,2,',','.'),0,1);
+$pdf->Cell(50,8,'Desconto IRRF:');
+$pdf->Cell(0,8,number_format($irrf,2,',','.'),0,1);
+$pdf->Cell(50,8,'Outros Descontos:');
+$pdf->Cell(0,8,number_format($outros,2,',','.'),0,1);
+$pdf->Cell(50,8,'Salario Liquido:');
+$pdf->Cell(0,8,number_format($salario_liquido,2,',','.'),0,1);
+
+$pdf->Output('I','folha_pagamento.pdf');
+


### PR DESCRIPTION
## Summary
- implement per-row PDF generation for payroll
- make payroll values editable by turning table cells into inputs
- add `gerar_pdf.php` that generates simple PDF using FPDF
- remove old unused PDF form

## Testing
- `php -l folha-pagamento.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686bc9499950832584a5f34f45e149d3