### PR TITLE
Ensure collaborator ID is submitted with manual time records

### DIFF
--- a/registro-ponto.php
+++ b/registro-ponto.php
@@ -131,7 +131,7 @@ while ($r = $res->fetch_assoc()) {
 <body>
   <div class="container">
     <h1>Registro de Ponto</h1>
-    <select id="userName">
+    <select id="userName" name="colaborador_id">
       <option value="">— Selecione o Colaborador —</option>
       <?php foreach($colabs as $c): ?>
       <option value="<?= $c['id'] ?>"><?= htmlspecialchars($c['nome']) ?></option>


### PR DESCRIPTION
## Summary
- include `name="colaborador_id"` in collaborator select to send correct ID

## Testing
- `php -l registro-ponto.php`


------
https://chatgpt.com/codex/tasks/task_e_68910a4265a483259a8437722a120ecf