### PR TITLE
Corrige registro de ponto manual para usar ID de colaborador

### DIFF
--- a/registro-ponto-manual.php
+++ b/registro-ponto-manual.php
@@ -41,7 +41,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if ($action === 'save') {
         $stmt = $db->prepare(
             "INSERT INTO registro_ponto
-             (colaborador_id, data_registro, horario_entrada, horario_saida, total, atividade, observacoes)
+             (id, data_registro, horario_entrada, horario_saida, total, atividade, observacoes)
              VALUES (?, ?, ?, ?, ?, ?, ?)"
         );
         $stmt->bind_param(
@@ -58,12 +58,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $_SESSION['flash'] = 'Apontamento cadastrado com sucesso!';
     } elseif ($action === 'update' && $id > 0) {
         $stmt = $db->prepare(
-            "UPDATE registro_ponto SET colaborador_id=?, data_registro=?, horario_entrada=?, horario_saida=?, total=?, atividade=?, observacoes=?
+            "UPDATE registro_ponto SET data_registro=?, horario_entrada=?, horario_saida=?, total=?, atividade=?, observacoes=?
              WHERE id=?"
         );
         $stmt->bind_param(
-            'issssssi',
-            $colaborador_id,
+            'ssssssi',
             $data,
             $horario_entrada,
             $horario_saida,
@@ -95,7 +94,7 @@ if (!empty($_GET['id'])) {
     $eid = intval($_GET['id']);
     $stmt = $db->prepare("SELECT rp.*, c.nome AS colaborador_nome
         FROM registro_ponto rp
-        JOIN colaboradores c ON rp.colaborador_id = c.id
+        JOIN colaboradores c ON rp.id = c.id
         WHERE rp.id = ?");
     $stmt->bind_param('i', $eid);
     $stmt->execute();
@@ -109,7 +108,7 @@ $end = $_GET['end_date'] ?? '';
 // Listagem com join para nome do colaborador e filtro por data
 $sql = "SELECT rp.*, c.nome AS colaborador_nome
         FROM registro_ponto rp
-        JOIN colaboradores c ON rp.colaborador_id = c.id";
+        JOIN colaboradores c ON rp.id = c.id";
 $params = [];
 if ($start && $end) {
     $sql .= " WHERE rp.data_registro BETWEEN ? AND ?";
@@ -291,7 +290,7 @@ $lista = $res->fetch_all(MYSQLI_ASSOC);
                 <div>
                     <label>Colaborador</label>
                     <input type="hidden" name="colaborador_id" id="colaborador_id"
-                        value="<?= $edit['colaborador_id'] ?? '' ?>">
+                        value="<?= $edit['id'] ?? '' ?>">
                     <input type="text" id="colaborador_label" class="autocomplete"
                         value="<?= htmlspecialchars($edit['colaborador_nome'] ?? '') ?>" required>
                 </div>


### PR DESCRIPTION
## Summary
- Usa ID do colaborador como chave do registro de ponto
- Remove campo `colaborador_id` das consultas e atualizações

## Testing
- `php -l registro-ponto-manual.php`


------
https://chatgpt.com/codex/tasks/task_e_6891149bad5883259d1e5a499d93f009